### PR TITLE
Update standard names bot stale issue message

### DIFF
--- a/.github/workflows/stale-issue-reminder.yml
+++ b/.github/workflows/stale-issue-reminder.yml
@@ -20,7 +20,8 @@ jobs:
         exempt-issue-labels: 'accepted'
         days-before-close: -1   # disabled
         only-issue-labels: standard name
-        stale-issue-message: 'This issue has had no activity in the last 30 days. This is a reminder to please comment on standard name requests to assist with agreement and acceptance. Standard name moderators are also reminded to review @feggleton @japamment '
+        stale-issue-message: 'This issue has had no activity in the last 30 days. If you proposed this issue or have contributed to the discussion, please reply to any outstanding concerns. If there has been little or no discussion, please comment on this issue, to assist with reaching a decision. If the proposal seems to have come to a consensus, please wait for the moderators to take the next steps towards acceptance. Standard name moderators are also reminded to review. @feggleton @japamment'
+
         days-before-stale: 30
         exempt-all-assignees: true
         stale-issue-label: moderator attention

--- a/.github/workflows/stale-issue-reminder.yml
+++ b/.github/workflows/stale-issue-reminder.yml
@@ -21,14 +21,19 @@ jobs:
         days-before-close: -1   # disabled
         only-issue-labels: standard name
         stale-issue-message: >
-          'This issue has had no activity in the last 30 days. If you
-          proposed this issue or have contributed to the discussion,
-          please reply to any outstanding concerns. If there has been
-          little or no discussion, please comment on this issue, to
-          assist with reaching a decision. If the proposal seems to
-          have come to a consensus, please wait for the moderators to
-          take the next steps towards acceptance. Standard name
-          moderators are also reminded to review. @feggleton @japamment'
+          'This issue has had no activity in the last 30 days.
+          Accordingly:
+
+          * If you proposed this issue or have contributed to the
+            discussion, please reply to any outstanding concerns.
+          * If there has been little or no discussion, please comment
+            on this issue, to assist with reaching a decision.
+          * If the proposal seems to have come to a consensus, please
+            wait for the moderators to take the next steps towards
+            acceptance.
+
+          Standard name moderators are also reminded to review.
+          @feggleton @japamment'
 
         days-before-stale: 30
         exempt-all-assignees: true

--- a/.github/workflows/stale-issue-reminder.yml
+++ b/.github/workflows/stale-issue-reminder.yml
@@ -20,7 +20,15 @@ jobs:
         exempt-issue-labels: 'accepted'
         days-before-close: -1   # disabled
         only-issue-labels: standard name
-        stale-issue-message: 'This issue has had no activity in the last 30 days. If you proposed this issue or have contributed to the discussion, please reply to any outstanding concerns. If there has been little or no discussion, please comment on this issue, to assist with reaching a decision. If the proposal seems to have come to a consensus, please wait for the moderators to take the next steps towards acceptance. Standard name moderators are also reminded to review. @feggleton @japamment'
+        stale-issue-message: >
+          'This issue has had no activity in the last 30 days. If you
+          proposed this issue or have contributed to the discussion,
+          please reply to any outstanding concerns. If there has been
+          little or no discussion, please comment on this issue, to
+          assist with reaching a decision. If the proposal seems to
+          have come to a consensus, please wait for the moderators to
+          take the next steps towards acceptance. Standard name
+          moderators are also reminded to review. @feggleton @japamment'
 
         days-before-stale: 30
         exempt-all-assignees: true

--- a/.github/workflows/stale-issue-reminder.yml
+++ b/.github/workflows/stale-issue-reminder.yml
@@ -20,9 +20,8 @@ jobs:
         exempt-issue-labels: 'accepted'
         days-before-close: -1   # disabled
         only-issue-labels: standard name
-        stale-issue-message: >
-          'This issue has had no activity in the last 30 days.
-          Accordingly:
+        stale-issue-message: |
+          This issue has had no activity in the last 30 days. Accordingly:
 
           * If you proposed this issue or have contributed to the
             discussion, please reply to any outstanding concerns.
@@ -31,9 +30,8 @@ jobs:
           * If the proposal seems to have come to a consensus, please
             wait for the moderators to take the next steps towards
             acceptance.
-
-          Standard name moderators are also reminded to review.
-          @feggleton @japamment'
+            
+          Standard name moderators are also reminded to review @feggleton @japamment
 
         days-before-stale: 30
         exempt-all-assignees: true


### PR DESCRIPTION
Close cf-convention/vocabularies#136 by updating the stale issue message that is raised by the GitHub Actions bot after an Issue on this repository has not been commented upon for around a month, as agreed over on the corresponding Issue.

Thanks to @JonathanGregory for the suggestion which we agreed to incorporate here.


### Notes
I have applied formatting within the string value set on the relevant value in the YAML, but as to whether the corresponding formatting (namely, line breaks and bullets) with be rendered in markdown when the message is raised by the bot, I am not sure. I'll try to create a similar message on a workflow in [my testing repo](https://github.com/sadielbartholomew/crash_test_dummy) to determine this. In the worst case and it doesn't render, we can revert the final commit to have it all as one long message without line-breaks, which still makes sense.

Note I have used a YAML validator to check that the new form is accepted.